### PR TITLE
Show add button in search

### DIFF
--- a/app/src/main/java/io/github/pelmenstar1/digiDict/ui/addEditRecord/AddEditRecordFragment.kt
+++ b/app/src/main/java/io/github/pelmenstar1/digiDict/ui/addEditRecord/AddEditRecordFragment.kt
@@ -53,8 +53,6 @@ class AddEditRecordFragment : Fragment() {
 
         vm.currentRecordId = recordId
 
-        // Init errors only after currentRecordId is set.
-        vm.initErrors()
         popBackStackOnSuccess(vm.addOrEditAction, navController)
         showSnackbarEventHandlerOnError(vm.addOrEditAction, container, R.string.dbError)
 
@@ -96,6 +94,13 @@ class AddEditRecordFragment : Fragment() {
         initMeaningInteraction()
         initBadgeInteraction()
         initViews()
+
+        args.initialExpression?.let {
+            binding.addRecordExpressionInputLayout.setText(it)
+        }
+
+        // Init errors only after currentRecordId and initial expression are set.
+        vm.initErrors()
 
         return binding.root
     }

--- a/app/src/main/java/io/github/pelmenstar1/digiDict/ui/addEditRecord/AddEditRecordViewModel.kt
+++ b/app/src/main/java/io/github/pelmenstar1/digiDict/ui/addEditRecord/AddEditRecordViewModel.kt
@@ -127,19 +127,21 @@ class AddEditRecordViewModel @Inject constructor(
     // setExpressionInternal shouldn't be called when there's 'current record' and it's not loaded.
     // It's not critical except 'check expression job' will be started earlier than it should be.
     private fun setExpressionInternal(value: String) {
-        _expression = value
+        if (value.isNotEmpty()) {
+            _expression = value
 
-        startCheckExprJobIfNecessary()
+            startCheckExprJobIfNecessary()
 
-        validity.update {
-            val prevValue = it ?: 0
+            validity.update {
+                val prevValue = it ?: 0
 
-            prevValue
-                .withBit(EXPRESSION_VALIDITY_BIT, false)
-                .withBit(EXPRESSION_VALIDITY_NOT_CHOSEN_BIT, true)
+                prevValue
+                    .withBit(EXPRESSION_VALIDITY_BIT, false)
+                    .withBit(EXPRESSION_VALIDITY_NOT_CHOSEN_BIT, true)
+            }
+
+            checkExpressionChannel.trySend(value)
         }
-
-        checkExpressionChannel.trySend(value)
     }
 
     // Must not be started if there's current record and it's null at the moment of calling method
@@ -173,6 +175,7 @@ class AddEditRecordViewModel @Inject constructor(
                             containsLetterOrDigit &&
                             (currentRecordExpression == expr || expressions.binarySearch(expr) < 0)
 
+                    // TODO: Remove possible add button blinking when checking takes too long
                     validity.update {
                         val prevValue = it ?: 0
 

--- a/app/src/main/java/io/github/pelmenstar1/digiDict/ui/home/search/SearchResult.kt
+++ b/app/src/main/java/io/github/pelmenstar1/digiDict/ui/home/search/SearchResult.kt
@@ -1,0 +1,21 @@
+package io.github.pelmenstar1.digiDict.ui.home.search
+
+import io.github.pelmenstar1.digiDict.common.FilteredArray
+import io.github.pelmenstar1.digiDict.data.ConciseRecordWithBadges
+
+class SearchResult(
+    /**
+     * Query of the search request.
+     */
+    val query: String,
+
+    /**
+     * Determines whether [query] is meaningful (contains at least one letter or digit)
+     */
+    val isMeaningfulQuery: Boolean,
+
+    /**
+     * The result of the search request.
+     */
+    val data: FilteredArray<ConciseRecordWithBadges>
+)

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -18,6 +18,35 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent" />
 
+        <LinearLayout
+            android:id="@+id/home_searchAddRecordContainer"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:layout_marginTop="8dp"
+            android:gravity="center_horizontal"
+            android:orientation="vertical"
+            android:visibility="gone"
+            tools:visibility="visible">
+
+            <TextView
+                style="@style/TextAppearance.Material3.BodyLarge"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_horizontal"
+                android:text="@string/home_searchNoResultsMessage" />
+
+            <Button
+                android:id="@+id/home_searchAddRecordButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_horizontal"
+                android:layout_marginTop="10dp"
+                android:text="@string/add" />
+
+        </LinearLayout>
+
+        <!-- TODO: Simplify it -->
         <include layout="@layout/home_loading_error_and_progress_merge" />
     </FrameLayout>
 

--- a/app/src/main/res/navigation/main_nav_graph.xml
+++ b/app/src/main/res/navigation/main_nav_graph.xml
@@ -38,6 +38,13 @@
             android:name="recordId"
             android:defaultValue="-1"
             app:argType="integer" />
+
+        <argument
+            android:name="initialExpression"
+            android:defaultValue="@null"
+            app:argType="string"
+            app:nullable="true" />
+
         <action
             android:id="@+id/action_addEditRecord_to_chooseRemoteDictionaryProvider"
             app:destination="@id/chooseRemoteDictionaryProviderFragment" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -50,6 +50,7 @@
     <!-- Home fragment -->
     <string name="home_label">Home</string>
     <string name="home_loadingError">There was an error during the loading of the records.</string>
+    <string name="home_searchNoResultsMessage">No results? Add a record then.</string>
 
     <!-- Remind records fragment -->
     <string name="remindRecords_labelInFragment">Remind</string>
@@ -110,6 +111,7 @@
     <string name="quizNav_all">All</string>
 
     <!-- Search fragment -->
+    <!-- TODO: Consolidate search_* with home fragment as they're logically connected -->
     <string name="search">Search</string>
     <string name="search_error">An error happened during the search</string>
 


### PR DESCRIPTION
Contributes to #9 

Adds a feature to show the 'add record' button when there are no results in the search.  It can be useful when you think you got the record with entered expression but it happens to be not and you want to add it.