### PR TITLE
Use GS as an element seperator in list meanings

### DIFF
--- a/app/schemas/io.github.pelmenstar1.digiDict.data.AppDatabase/11.json
+++ b/app/schemas/io.github.pelmenstar1.digiDict.data.AppDatabase/11.json
@@ -1,0 +1,250 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 11,
+    "identityHash": "0b01084463ef24910b3afc38e47d626f",
+    "entities": [
+      {
+        "tableName": "records",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `expression` TEXT NOT NULL, `meaning` TEXT NOT NULL, `additionalNotes` TEXT NOT NULL, `score` INTEGER NOT NULL, `dateTime` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "expression",
+            "columnName": "expression",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "meaning",
+            "columnName": "meaning",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "additionalNotes",
+            "columnName": "additionalNotes",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "score",
+            "columnName": "score",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "epochSeconds",
+            "columnName": "dateTime",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_records_expression",
+            "unique": true,
+            "columnNames": [
+              "expression"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_records_expression` ON `${TABLE_NAME}` (`expression`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "remote_dict_providers",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `schema` TEXT NOT NULL, `urlEncodingRules` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "schema",
+            "columnName": "schema",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "urlEncodingRules",
+            "columnName": "urlEncodingRules",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "remote_dict_provider_stats",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `visitCount` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "visitCount",
+            "columnName": "visitCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "record_badges",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `outlineColor` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "outlineColor",
+            "columnName": "outlineColor",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_record_badges_name",
+            "unique": true,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_record_badges_name` ON `${TABLE_NAME}` (`name`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "record_to_badge_relations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`relationId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `recordId` INTEGER NOT NULL, `badgeId` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "relationId",
+            "columnName": "relationId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "recordId",
+            "columnName": "recordId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "badgeId",
+            "columnName": "badgeId",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "relationId"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "events",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `startEpochSeconds` INTEGER NOT NULL, `endEpochSeconds` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startEpochSeconds",
+            "columnName": "startEpochSeconds",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endEpochSeconds",
+            "columnName": "endEpochSeconds",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '0b01084463ef24910b3afc38e47d626f')"
+    ]
+  }
+}

--- a/app/src/androidTest/java/io/github/pelmenstar1/digiDict/HomeSearchStyledTextUtilTests.kt
+++ b/app/src/androidTest/java/io/github/pelmenstar1/digiDict/HomeSearchStyledTextUtilTests.kt
@@ -6,6 +6,7 @@ import androidx.core.text.getSpans
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import io.github.pelmenstar1.digiDict.common.mapToArray
+import io.github.pelmenstar1.digiDict.data.ComplexMeaning
 import io.github.pelmenstar1.digiDict.ui.MeaningTextHelper
 import io.github.pelmenstar1.digiDict.ui.home.search.HomeSearchItemStyle
 import io.github.pelmenstar1.digiDict.ui.home.search.HomeSearchStyledTextUtil
@@ -138,13 +139,13 @@ class HomeSearchStyledTextUtilTests {
         )
 
         testCase(
-            meaning = "L2@ABCD\nFFF",
+            meaning = "L2@ABCD${ComplexMeaning.LIST_NEW_ELEMENT_SEPARATOR}FFF",
             foundSections = arrayOf(IntRangeSection(1 until 3), IntRangeSection(0 until 2)),
             expectedRanges = arrayOf(3 until 5, 9 until 11)
         )
 
         testCase(
-            meaning = "L2@ABCD\nFFF",
+            meaning = "L2@ABCD${ComplexMeaning.LIST_NEW_ELEMENT_SEPARATOR}FFF",
             foundSections = emptyArray(),
             expectedRanges = emptyArray()
         )

--- a/app/src/androidTest/java/io/github/pelmenstar1/digiDict/RecordDeepSearchCoreTests.kt
+++ b/app/src/androidTest/java/io/github/pelmenstar1/digiDict/RecordDeepSearchCoreTests.kt
@@ -1,6 +1,7 @@
 package io.github.pelmenstar1.digiDict
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.github.pelmenstar1.digiDict.data.ComplexMeaning
 import io.github.pelmenstar1.digiDict.data.ConciseRecordWithBadges
 import io.github.pelmenstar1.digiDict.search.RecordDeepSearchCore
 import io.github.pelmenstar1.digiDict.search.RecordSearchOptions
@@ -217,14 +218,14 @@ class RecordDeepSearchCoreTests {
 
         testCase(
             expr = "Expression",
-            meaning = "L2@Mean\nKind",
+            meaning = "L2@Mean${ComplexMeaning.LIST_NEW_ELEMENT_SEPARATOR}Kind",
             query = "mEa",
             expectedResult = true
         )
 
         testCase(
             expr = "Expression",
-            meaning = "L2@Mean\nKind",
+            meaning = "L2@Mean${ComplexMeaning.LIST_NEW_ELEMENT_SEPARATOR}Kind",
             query = "kin",
             expectedResult = true
         )
@@ -254,7 +255,7 @@ class RecordDeepSearchCoreTests {
 
         testCase(
             expr = "give",
-            meaning = "L2@A\nB",
+            meaning = "L2@A${ComplexMeaning.LIST_NEW_ELEMENT_SEPARATOR}B",
             query = "A",
             expectedResult = false
         )
@@ -284,7 +285,7 @@ class RecordDeepSearchCoreTests {
 
         testCase(
             expr = "A",
-            meaning = "L2@C\nB",
+            meaning = "L2@C${ComplexMeaning.LIST_NEW_ELEMENT_SEPARATOR}B",
             query = "A",
             expectedResult = false
         )

--- a/app/src/androidTest/java/io/github/pelmenstar1/digiDict/RecordSearchMetadataProviderOnCoreTests.kt
+++ b/app/src/androidTest/java/io/github/pelmenstar1/digiDict/RecordSearchMetadataProviderOnCoreTests.kt
@@ -149,6 +149,8 @@ class RecordSearchMetadataProviderOnCoreTests {
             assertContentEquals(expectedSections, actualSections)
         }
 
+        val listSep = ComplexMeaning.LIST_NEW_ELEMENT_SEPARATOR
+
         testCase(
             meaning = "CABC AB BB",
             query = "AB",
@@ -204,7 +206,7 @@ class RecordSearchMetadataProviderOnCoreTests {
         )
 
         testCase(
-            meaning = "L3@ABC\nABC\nAB",
+            meaning = "L3@ABC${listSep}ABC${listSep}AB",
             query = "AB",
             expectedSections = arrayOf(
                 IntRangeSection(0 until 2),
@@ -214,7 +216,7 @@ class RecordSearchMetadataProviderOnCoreTests {
         )
 
         testCase(
-            meaning = "L2@B LL\nA",
+            meaning = "L2@B LL${listSep}A",
             query = "LL",
             expectedSections = arrayOf(
                 IntRangeSection(2 until 4),
@@ -223,7 +225,7 @@ class RecordSearchMetadataProviderOnCoreTests {
         )
 
         testCase(
-            meaning = "L2@B\nget",
+            meaning = "L2@B${listSep}get",
             query = "get",
             expectedSections = arrayOf(
                 IntRangeSection(),
@@ -232,7 +234,7 @@ class RecordSearchMetadataProviderOnCoreTests {
         )
 
         testCase(
-            meaning = "L2@aaa\nabc def  xyz",
+            meaning = "L2@aaa${listSep}abc def  xyz",
             query = "def xyz",
             expectedSections = arrayOf(
                 IntRangeSection(),
@@ -241,7 +243,7 @@ class RecordSearchMetadataProviderOnCoreTests {
         )
 
         testCase(
-            meaning = "L2@aaa\nabc def  xyz",
+            meaning = "L2@aaa${listSep}abc def  xyz",
             query = "def xy",
             expectedSections = arrayOf(
                 IntRangeSection(),
@@ -250,7 +252,7 @@ class RecordSearchMetadataProviderOnCoreTests {
         )
 
         testCase(
-            meaning = "L2@aaa\nabc def  xyz def   xyz",
+            meaning = "L2@aaa${listSep}abc def  xyz def   xyz",
             query = "def xyz",
             expectedSections = arrayOf(
                 IntRangeSection(),
@@ -276,7 +278,8 @@ class RecordSearchMetadataProviderOnCoreTests {
 
         val provider = RecordSearchMetadataProviderOnCore(RecordDeepSearchCore, query = "AB", options)
 
-        val data = provider.calculateFoundRanges(createRecord(expr = "AB", meaning = "L3@AB\nBC\nCD"))
+        val listSep = ComplexMeaning.LIST_NEW_ELEMENT_SEPARATOR
+        val data = provider.calculateFoundRanges(createRecord(expr = "AB", meaning = "L3@AB${listSep}BC${listSep}CD"))
 
         assertEquals(1, data[0]) // first is expr ranges length, should be one, as there's one range.
         assertEquals(0, data[1]) // the start of the expr range

--- a/app/src/main/java/io/github/pelmenstar1/digiDict/backup/BackupCompatInfo.kt
+++ b/app/src/main/java/io/github/pelmenstar1/digiDict/backup/BackupCompatInfo.kt
@@ -4,25 +4,34 @@ import io.github.pelmenstar1.digiDict.common.binarySerialization.BinarySerializa
 import io.github.pelmenstar1.digiDict.common.equalsPattern
 import kotlinx.serialization.Serializable
 
-// For now, it's empty. In future, some properties will be added.
 @Serializable
-class BackupCompatInfo {
+class BackupCompatInfo(val newMeaningFormat: Boolean = false) {
     fun toBinarySerializationCompatInfo(): BinarySerializationCompatInfo {
-        return BinarySerializationCompatInfo.empty()
+        var bits = 0L
+
+        if (newMeaningFormat) {
+            bits = bits or (1L shl NEW_MEANING_FORMAT_INDEX)
+        }
+
+        return BinarySerializationCompatInfo(bits)
     }
 
-    override fun equals(other: Any?) = equalsPattern(other) { true }
+    override fun equals(other: Any?) = equalsPattern(other) { o ->
+        newMeaningFormat == o.newMeaningFormat
+    }
 
     override fun hashCode(): Int {
-        return 0
+        return if (newMeaningFormat) 1 else 0
     }
 
     override fun toString(): String {
-        return "BackupCompatInfo()"
+        return "BackupCompatInfo(newMeaningFormat=$newMeaningFormat)"
     }
 
     companion object {
         private val EMPTY = BackupCompatInfo()
+
+        const val NEW_MEANING_FORMAT_INDEX = 0
 
         fun empty() = EMPTY
     }

--- a/app/src/main/java/io/github/pelmenstar1/digiDict/data/AppDatabase.kt
+++ b/app/src/main/java/io/github/pelmenstar1/digiDict/data/AppDatabase.kt
@@ -18,7 +18,7 @@ import io.github.pelmenstar1.digiDict.common.getLazyValue
         EventInfo::class
     ],
     exportSchema = true,
-    version = 10,
+    version = 11,
     autoMigrations = [
         AutoMigration(
             from = 1,
@@ -98,6 +98,13 @@ abstract class AppDatabase : RoomDatabase() {
         }
     }
 
+    object Migration_10_11 : Migration(10, 11) {
+        override fun migrate(database: SupportSQLiteDatabase) {
+            // L% to replace new lines only in list meanings.
+            database.execSQL("UPDATE records SET meaning=replace(meaning, '${ComplexMeaning.LIST_OLD_ELEMENT_SEPARATOR}', '${ComplexMeaning.LIST_NEW_ELEMENT_SEPARATOR}') WHERE meaning LIKE 'L%'")
+        }
+    }
+
     abstract fun recordDao(): RecordDao
     abstract fun remoteDictionaryProviderDao(): RemoteDictionaryProviderDao
     abstract fun remoteDictionaryProviderStatsDao(): RemoteDictionaryProviderStatsDao
@@ -160,7 +167,7 @@ abstract class AppDatabase : RoomDatabase() {
         }
 
         private fun Builder<AppDatabase>.configureAndBuild(): AppDatabase =
-            this.addMigrations(Migration_2_3, Migration_3_4, Migration_4_5, Migration_5_6)
+            this.addMigrations(Migration_2_3, Migration_3_4, Migration_4_5, Migration_5_6, Migration_10_11)
                 .addCallback(object : Callback() {
                     override fun onCreate(db: SupportSQLiteDatabase) {
                         db.insertRemoteDictProviders_5(RemoteDictionaryProviderInfo.PREDEFINED_PROVIDERS)

--- a/app/src/main/java/io/github/pelmenstar1/digiDict/data/ComplexMeaning.kt
+++ b/app/src/main/java/io/github/pelmenstar1/digiDict/data/ComplexMeaning.kt
@@ -291,12 +291,25 @@ sealed class ComplexMeaning : Parcelable {
         }
 
         /**
-         * Converts a list meaning encoded in old format (with \n as element separator) to a new list meaning format.
+         * Converts a list meaning encoded in old format (with \n as element separator) to the new list meaning format.
          */
         fun recodeListOldFormatToNew(meaning: String): String {
             return meaning.replace(LIST_OLD_ELEMENT_SEPARATOR, LIST_NEW_ELEMENT_SEPARATOR)
         }
 
+        /**
+         * Converts a list meaning encoded in new format to the old meaning format.
+         *
+         * [meaning] should not contain any \n as a part of the list elements.
+         */
+        fun recodeListNewFormatToOld(meaning: String): String {
+            return meaning.replace(LIST_NEW_ELEMENT_SEPARATOR, LIST_OLD_ELEMENT_SEPARATOR)
+        }
+
+        /**
+         * Finds an index of [ComplexMeaning.LIST_NEW_ELEMENT_SEPARATOR] in the given string starting from [startIndex].
+         * If the index is not found, returns length of the string.
+         */
         fun indexOfListSeparatorOrLength(str: String, startIndex: Int): Int {
             var index = str.indexOf(LIST_NEW_ELEMENT_SEPARATOR, startIndex)
             if (index < 0) {

--- a/app/src/main/java/io/github/pelmenstar1/digiDict/ui/MeaningTextHelper.kt
+++ b/app/src/main/java/io/github/pelmenstar1/digiDict/ui/MeaningTextHelper.kt
@@ -47,30 +47,18 @@ object MeaningTextHelper {
                     buffer[bufferIndex++] = BULLET_LIST_CHARACTER
                     buffer[bufferIndex++] = ' '
 
-                    var nextDelimiterPos = meaning.indexOf('\n', textIndex)
-                    if (nextDelimiterPos < 0) {
-                        nextDelimiterPos = textLength
-                    } else {
-                        // To add leading new-line to buffer.
-                        nextDelimiterPos++
-                    }
+                    val nextDelimiterPos = ComplexMeaning.indexOfListSeparatorOrLength(meaning, textIndex)
 
                     // Write to buffer at its current position the part of text between previous and next element.
-                    // Example: L2@ABCDABC\nL
-                    //             ^      ^
-                    //           from A  to new-line (inclusive)
                     meaning.toCharArray(buffer, bufferIndex, textIndex, nextDelimiterPos)
+                    bufferIndex += nextDelimiterPos - textIndex
+
+                    if (nextDelimiterPos != textLength) {
+                        buffer[bufferIndex++] = '\n'
+                    }
 
                     // Move bufferIndex forward to the end position of the written part to continue with a next element.
-                    // Example: Meaning= L2@ABCDABC\nL
-                    //          Buffer = '• ABCDABC\n'
-                    //                      ^       ^
-                    //                   previous | new position
-                    //                   position | after a new-line
-                    //                   (where A) \ - - - - - - - -
-                    //                - - - - - - -/
-                    bufferIndex += nextDelimiterPos - textIndex
-                    textIndex = nextDelimiterPos
+                    textIndex = nextDelimiterPos + 1
                 }
 
                 return String(buffer)

--- a/app/src/main/java/io/github/pelmenstar1/digiDict/ui/addEditRecord/MeaningListInteractionView.kt
+++ b/app/src/main/java/io/github/pelmenstar1/digiDict/ui/addEditRecord/MeaningListInteractionView.kt
@@ -136,6 +136,7 @@ class MeaningListInteractionView @JvmOverloads constructor(
     private val emptyTextError: String
     private var duplicateError: String? = null
     private var noLetterOrDigitError: String? = null
+    private var illegalCharactersError: String? = null
 
     private var meaningAndOrdinalFormat: String? = null
     private val meaningStr: String
@@ -308,6 +309,7 @@ class MeaningListInteractionView @JvmOverloads constructor(
             val error = when {
                 element.isEmpty() -> ERROR_EMPTY_TEXT
                 !element.containsLetterOrDigit() -> ERROR_NO_LETTER_OR_DIGIT
+                element.contains(ComplexMeaning.LIST_NEW_ELEMENT_SEPARATOR) -> ERROR_ILLEGAL_CHARACTERS
                 duplicateBitSet[index] -> ERROR_DUPLICATE
                 else -> ERROR_NONE
             }
@@ -332,6 +334,10 @@ class MeaningListInteractionView @JvmOverloads constructor(
                 noLetterOrDigitError,
                 R.string.addEditRecord_meaningNoLetterOrDigit,
             ) { noLetterOrDigitError = it }
+            ERROR_ILLEGAL_CHARACTERS -> res.getLazyString(
+                illegalCharactersError,
+                R.string.addEditRecord_meaningIllegalCharactersError
+            ) { illegalCharactersError = it }
             else -> null
         }
     }
@@ -467,6 +473,7 @@ class MeaningListInteractionView @JvmOverloads constructor(
         private const val ERROR_EMPTY_TEXT = 1
         private const val ERROR_DUPLICATE = 2
         private const val ERROR_NO_LETTER_OR_DIGIT = 3
+        private const val ERROR_ILLEGAL_CHARACTERS = 4
 
         internal inline fun Resources.getLazyString(cached: String?, id: Int, set: (String) -> Unit): String {
             return getLazyValue(cached, { getString(id) }, set)

--- a/app/src/main/java/io/github/pelmenstar1/digiDict/ui/exportConfig/ExportConfigurationViewModel.kt
+++ b/app/src/main/java/io/github/pelmenstar1/digiDict/ui/exportConfig/ExportConfigurationViewModel.kt
@@ -32,7 +32,8 @@ class ExportConfigurationViewModel @Inject constructor(
             val data = BackupManager.createBackupData(
                 appDatabase,
                 options,
-                reporter.subReporter(completed = 0, target = 50)  // Treat extracting the data as half of the job.
+                // Treat extracting the data as half of the job.
+                progressReporter = reporter.subReporter(completed = 0, target = 50)
             )
 
             val format = selectedFormat!!

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -112,6 +112,7 @@
     <string name="addEditRecord_meaningNoLetterOrDigit">Meaning should contain at least one letter or digit</string>
     <string name="addEditRecord_outlineColor">Outline color</string>
     <string name="addEditRecord_doNotChangeCreationTime">Don\'t change creation time</string>
+    <string name="addEditRecord_meaningIllegalCharactersError">Meaning contains illegal characters (Group separator)</string>
 
     <string name="badgeInteraction_badge">Badge</string>
     <string name="badgeSelector_manage">Manage badges</string>

--- a/app/src/test/java/io/github/pelmenstar1/digiDict/ComplexMeaningTests.kt
+++ b/app/src/test/java/io/github/pelmenstar1/digiDict/ComplexMeaningTests.kt
@@ -74,4 +74,75 @@ class ComplexMeaningTests {
         testCase("L1@", expectedRanges = arrayOf(3 to 3))
         testCase("L2@1${listSep}", expectedRanges = arrayOf(3 to 4, 5 to 5))
     }
+
+    @Test
+    fun getMeaningCountTest() {
+        fun testCase(meaning: String, expectedCount: Int) {
+            val actualCount = ComplexMeaning.getMeaningCount(meaning)
+
+            assertEquals(expectedCount, actualCount, "meaning: $meaning")
+        }
+
+        val listSep = ComplexMeaning.LIST_NEW_ELEMENT_SEPARATOR
+
+        testCase(meaning = "CMeaning", expectedCount = 1)
+        testCase(meaning = "L2@Meaning1${listSep}Meaning2", expectedCount = 2)
+        testCase(meaning = "L3@Meaning1${listSep}Meaning2${listSep}Meaning3", expectedCount = 3)
+    }
+
+    @Test
+    fun recodeListOldFormatToNewTest() {
+        fun testCase(input: String, expectedMeaning: String) {
+            val actualMeaning = ComplexMeaning.recodeListOldFormatToNew(input)
+
+            assertEquals(expectedMeaning, actualMeaning, "input: $input")
+        }
+
+        val listSep = ComplexMeaning.LIST_NEW_ELEMENT_SEPARATOR
+
+        testCase(
+            input = "L2@Meaning1\nMeaning2",
+            expectedMeaning = "L2@Meaning1${listSep}Meaning2"
+        )
+        testCase(
+            input = "L3@Meaning1\nMeaning2\nMeaning3",
+            expectedMeaning = "L3@Meaning1${listSep}Meaning2${listSep}Meaning3"
+        )
+    }
+
+    @Test
+    fun recodeListNewFormatToOldTest() {
+        fun testCase(input: String, expectedMeaning: String) {
+            val actualMeaning = ComplexMeaning.recodeListNewFormatToOld(input)
+
+            assertEquals(expectedMeaning, actualMeaning, "input: $input")
+        }
+
+        val listSep = ComplexMeaning.LIST_NEW_ELEMENT_SEPARATOR
+
+        testCase(
+            input = "L2@Meaning1${listSep}Meaning2",
+            expectedMeaning = "L2@Meaning1\nMeaning2"
+        )
+        testCase(
+            input = "L3@Meaning1${listSep}Meaning2${listSep}Meaning3",
+            expectedMeaning = "L3@Meaning1\nMeaning2\nMeaning3"
+        )
+    }
+
+    @Test
+    fun indexOfListSeparatorOrLengthTest() {
+        fun testCase(meaning: String, startIndex: Int, expectedIndex: Int) {
+            val actualIndex = ComplexMeaning.indexOfListSeparatorOrLength(meaning, startIndex)
+
+            assertEquals(expectedIndex, actualIndex, "meaning: $meaning startIndex: $startIndex")
+        }
+
+        val listSep = ComplexMeaning.LIST_NEW_ELEMENT_SEPARATOR
+
+        testCase(meaning = "123${listSep}4", startIndex = 0, expectedIndex = 3)
+        testCase(meaning = "1234", startIndex = 0, expectedIndex = 4)
+        testCase(meaning = "1${listSep}2${listSep}", startIndex = 2, expectedIndex = 3)
+        testCase(meaning = "1${listSep}2345", startIndex = 2, expectedIndex = 6)
+    }
 }

--- a/app/src/test/java/io/github/pelmenstar1/digiDict/ComplexMeaningTests.kt
+++ b/app/src/test/java/io/github/pelmenstar1/digiDict/ComplexMeaningTests.kt
@@ -7,26 +7,27 @@ import kotlin.test.assertEquals
 
 class ComplexMeaningTests {
     @Test
-    fun `create common test`() {
+    fun createCommonTest() {
         assertEquals(ComplexMeaning.Common("123").rawText, "C123")
         assertEquals(ComplexMeaning.Common("ABCD").rawText, "CABCD")
         assertEquals(ComplexMeaning.Common("").rawText, "C")
     }
 
     @Test
-    fun `create list test`() {
-        @Suppress("UNCHECKED_CAST")
+    fun createListTest() {
         fun testCase(expected: String, vararg elements: String) {
-            assertEquals(expected, ComplexMeaning.List(elements as Array<String>).rawText)
+            assertEquals(expected, ComplexMeaning.List(elements).rawText)
         }
 
-        testCase("L3@E_1\nE_2\nE_3", "E_1", "E_2", "E_3")
+        val listSep = ComplexMeaning.LIST_NEW_ELEMENT_SEPARATOR
+
+        testCase("L3@E_1${listSep}E_2${listSep}E_3", "E_1", "E_2", "E_3")
         testCase("L0@")
         testCase("L1@E_1", "E_1")
     }
 
     @Test
-    fun `parse with common meaning test`() {
+    fun parseWithCommonMeaningTest() {
         fun testCase(expected: ComplexMeaning.Common, input: String) {
             assertEquals(expected, ComplexMeaning.parse(input))
         }
@@ -37,22 +38,24 @@ class ComplexMeaningTests {
     }
 
     @Test
-    fun `parse with list meaning test`() {
+    fun parseWithListMeaningTest() {
         fun testCase(expected: ComplexMeaning.List, input: String) {
             val actual = ComplexMeaning.parse(input)
 
             assertEquals(expected, actual)
         }
 
-        testCase(ComplexMeaning.List(arrayOf("1", "2", "3")), "L3@1\n2\n3")
+        val listSep = ComplexMeaning.LIST_NEW_ELEMENT_SEPARATOR
+
+        testCase(ComplexMeaning.List(arrayOf("1", "2", "3")), "L3@1${listSep}2${listSep}3")
         testCase(ComplexMeaning.List(emptyArray()), "L0@")
         testCase(ComplexMeaning.List(arrayOf("1")), "L1@1")
-        testCase(ComplexMeaning.List(arrayOf("1", "", "3")), "L3@1\n\n3")
+        testCase(ComplexMeaning.List(arrayOf("1", "", "3")), "L3@1${listSep}${listSep}3")
     }
 
 
     @Test
-    fun `iterateListElementRanges test`() {
+    fun iterateListElementRangesTest() {
         fun testCase(text: String, expectedRanges: Array<Pair<Int, Int>>) {
             val actualRanges = ArrayList<Pair<Int, Int>>()
 
@@ -63,10 +66,12 @@ class ComplexMeaningTests {
             assertContentEquals(expectedRanges, actualRanges.toTypedArray())
         }
 
+        val listSep = ComplexMeaning.LIST_NEW_ELEMENT_SEPARATOR
+
         testCase("L1@A", expectedRanges = arrayOf(3 to 4))
         testCase("L0@", expectedRanges = emptyArray())
-        testCase("L3@Abcc\nb\n1", expectedRanges = arrayOf(3 to 7, 8 to 9, 10 to 11))
+        testCase("L3@Abcc${listSep}b${listSep}1", expectedRanges = arrayOf(3 to 7, 8 to 9, 10 to 11))
         testCase("L1@", expectedRanges = arrayOf(3 to 3))
-        testCase("L2@1\n", expectedRanges = arrayOf(3 to 4, 5 to 5))
+        testCase("L2@1${listSep}", expectedRanges = arrayOf(3 to 4, 5 to 5))
     }
 }

--- a/app/src/test/java/io/github/pelmenstar1/digiDict/MeaningTextHelperTests.kt
+++ b/app/src/test/java/io/github/pelmenstar1/digiDict/MeaningTextHelperTests.kt
@@ -1,5 +1,6 @@
 package io.github.pelmenstar1.digiDict
 
+import io.github.pelmenstar1.digiDict.data.ComplexMeaning
 import io.github.pelmenstar1.digiDict.ui.MeaningTextHelper
 import org.junit.Test
 import kotlin.test.assertEquals
@@ -20,12 +21,17 @@ class MeaningTextHelperTests {
 
     @Test
     fun formatListTest() {
+        val delimiter = ComplexMeaning.LIST_NEW_ELEMENT_SEPARATOR
+
         formatTestHelper(meaning = "L1@M", expected = "• M")
         formatTestHelper(meaning = "L1@MMM", expected = "• MMM")
-        formatTestHelper(meaning = "L2@MMM\nN", expected = "• MMM\n• N")
-        formatTestHelper(meaning = "L4@AA\nB\nCCC\nD", expected = "• AA\n• B\n• CCC\n• D")
-        formatTestHelper(meaning = "L2@Meaning 1\nMeaning 2", expected = "• Meaning 1\n• Meaning 2")
-        formatTestHelper(meaning = "L2@A lot of words\nMore words", expected = "• A lot of words\n• More words")
+        formatTestHelper(meaning = "L2@MMM${delimiter}N", expected = "• MMM\n• N")
+        formatTestHelper(meaning = "L4@AA${delimiter}B${delimiter}CCC${delimiter}D", expected = "• AA\n• B\n• CCC\n• D")
+        formatTestHelper(meaning = "L2@Meaning 1${delimiter}Meaning 2", expected = "• Meaning 1\n• Meaning 2")
+        formatTestHelper(
+            meaning = "L2@A lot of words${delimiter}More words",
+            expected = "• A lot of words\n• More words"
+        )
     }
 
     @Test

--- a/common/src/main/java/io/github/pelmenstar1/digiDict/common/binarySerialization/BinarySerializationCompatInfo.kt
+++ b/common/src/main/java/io/github/pelmenstar1/digiDict/common/binarySerialization/BinarySerializationCompatInfo.kt
@@ -28,22 +28,3 @@ class BinarySerializationCompatInfo(val bits: Long) {
         fun empty() = EMPTY
     }
 }
-
-class BinarySerializationCompatInfoBuilder {
-    private var bits = 0L
-
-    /**
-     * Sets the bit at given [index].
-     */
-    fun set(index: Int) {
-        require(index in 0 until 64) { "Index is out of bounds" }
-
-        bits = bits or (1L shl index)
-    }
-
-    fun create() = BinarySerializationCompatInfo(bits)
-}
-
-inline fun BinarySerializationCompatInfo(block: BinarySerializationCompatInfoBuilder.() -> Unit): BinarySerializationCompatInfo {
-    return BinarySerializationCompatInfoBuilder().also(block).create()
-}


### PR DESCRIPTION
This will allow new lines in meaning because they are no longer used as separators. This is also possible because of recently added compatibility info support in backups