### PR TITLE
Use UTF8 as default encoding in binary serialization

### DIFF
--- a/app/src/androidTest/java/io/github/pelmenstar1/digiDict/BackupManagerTests.kt
+++ b/app/src/androidTest/java/io/github/pelmenstar1/digiDict/BackupManagerTests.kt
@@ -22,7 +22,7 @@ import kotlin.test.assertEquals
 @RunWith(AndroidJUnit4::class)
 class BackupManagerTests {
     private val context = ApplicationProvider.getApplicationContext<Context>()
-    private val recordCounts = intArrayOf(1, 4, 16, 128, 1024)
+    private val recordCounts = intArrayOf(1 /* 4, 16, 128, 1024 */)
     private val badgeCounts = intArrayOf(1, 2, 4, 8)
 
     private val dddbVersions = intArrayOf(0, 1)
@@ -33,6 +33,12 @@ class BackupManagerTests {
             // Truncate the file.
             RandomAccessFile(it, "rw").setLength(0L)
         }
+    }
+
+    private fun latestCompatInfoForVersion(version: Int): BackupCompatInfo = when (version) {
+        0 -> BackupCompatInfo.empty()
+        1 -> BackupManager.latestCompatInfo
+        else -> throw IllegalArgumentException("version")
     }
 
     private fun createNoIdBadges(size: Int, colorAddition: Int = 0): Array<RecordBadgeInfo> {
@@ -69,7 +75,7 @@ class BackupManagerTests {
         format: BackupFormat,
         size: Int,
         exportVersion: Int,
-        compatInfo: BackupCompatInfo = BackupManager.latestCompatInfo
+        compatInfo: BackupCompatInfo = latestCompatInfoForVersion(exportVersion)
     ) = useInMemoryDb(context) { db ->
         val file = backupFile(format)
 
@@ -90,7 +96,7 @@ class BackupManagerTests {
         recordCount: Int,
         badgeCount: Int,
         exportVersion: Int,
-        compatInfo: BackupCompatInfo = BackupManager.latestCompatInfo
+        compatInfo: BackupCompatInfo = latestCompatInfoForVersion(exportVersion)
     ) = useInMemoryDb(context) { db ->
         val file = backupFile(format)
 
@@ -125,7 +131,8 @@ class BackupManagerTests {
         format: BackupFormat,
         recordCount: Int,
         badgeCount: Int,
-        exportVersion: Int
+        exportVersion: Int,
+        compatInfo: BackupCompatInfo = latestCompatInfoForVersion(exportVersion)
     ) = useInMemoryDb(context) { db ->
         val file = backupFile(format)
 
@@ -137,7 +144,7 @@ class BackupManagerTests {
         val badgesToExport = badgeDao.getAllOrderByIdAsc()
         insertBadgeRelations(db, badgesToExport)
 
-        file.export(db, ExportOptions(exportBadges = true), format, exportVersion)
+        file.export(db, ExportOptions(exportBadges = true), format, exportVersion, compatInfo)
 
         db.clearAllTables()
         insertBadges(db, badgeCount, colorAddition = 1)

--- a/app/src/androidTest/java/io/github/pelmenstar1/digiDict/BackupManagerTests.kt
+++ b/app/src/androidTest/java/io/github/pelmenstar1/digiDict/BackupManagerTests.kt
@@ -8,6 +8,7 @@ import io.github.pelmenstar1.digiDict.backup.BackupFormat
 import io.github.pelmenstar1.digiDict.backup.BackupManager
 import io.github.pelmenstar1.digiDict.backup.exporting.ExportOptions
 import io.github.pelmenstar1.digiDict.backup.importing.ImportOptions
+import io.github.pelmenstar1.digiDict.common.debugLog
 import io.github.pelmenstar1.digiDict.common.unsafeNewArray
 import io.github.pelmenstar1.digiDict.data.*
 import io.github.pelmenstar1.digiDict.utils.assertContentEqualsNoId
@@ -22,7 +23,7 @@ import kotlin.test.assertEquals
 @RunWith(AndroidJUnit4::class)
 class BackupManagerTests {
     private val context = ApplicationProvider.getApplicationContext<Context>()
-    private val recordCounts = intArrayOf(1 /* 4, 16, 128, 1024 */)
+    private val recordCounts = intArrayOf(1, 4, 16, 128, 1024)
     private val badgeCounts = intArrayOf(1, 2, 4, 8)
 
     private val dddbVersions = intArrayOf(0, 1)
@@ -89,6 +90,10 @@ class BackupManagerTests {
         val importedRecordsInDb = getAllRecordsNoIdInSet(db)
 
         assertEquals(records, importedRecordsInDb)
+
+        debugLog(TAG) {
+            info("(only records) format=${format.name} version=$exportVersion compatInfo=${compatInfo} records length = $size file length = ${file.length()} bytes")
+        }
     }
 
     private suspend fun roundtripWithBadgesPreserve(
@@ -125,6 +130,10 @@ class BackupManagerTests {
         assertContentEqualsNoId(noIdNewBadges, importedBadges)
 
         validateBadgeRelations(db, importedBadges)
+
+        debugLog(TAG) {
+            info("(records with badges) format=${format.name} version = $exportVersion compatInfo=${compatInfo} records length = $recordCount badges length = $badgeCount file length = ${file.length()} bytes")
+        }
     }
 
     private suspend fun roundtripWithBadgesReplace(
@@ -424,5 +433,9 @@ class BackupManagerTests {
                 }
             }
         }
+    }
+
+    companion object {
+        private const val TAG = "BackupManagerTests"
     }
 }

--- a/app/src/main/java/io/github/pelmenstar1/digiDict/backup/BackupCompatInfo.kt
+++ b/app/src/main/java/io/github/pelmenstar1/digiDict/backup/BackupCompatInfo.kt
@@ -5,33 +5,49 @@ import io.github.pelmenstar1.digiDict.common.equalsPattern
 import kotlinx.serialization.Serializable
 
 @Serializable
-class BackupCompatInfo(val newMeaningFormat: Boolean = false) {
-    fun toBinarySerializationCompatInfo(): BinarySerializationCompatInfo {
+class BackupCompatInfo(
+    val newMeaningFormat: Boolean = false,
+
+    // Transient because only JSON format is used with Kotlin serialization and it's always UTF8.
+    // This is property is only used in binary serialization.
+    @kotlinx.serialization.Transient val isUtf8Strings: Boolean = false
+) {
+    private fun toBinarySerializationCompatInfoBits(): Long {
         var bits = 0L
 
         if (newMeaningFormat) {
             bits = bits or (1L shl NEW_MEANING_FORMAT_INDEX)
         }
 
-        return BinarySerializationCompatInfo(bits)
+        if (isUtf8Strings) {
+            bits = bits or (1L shl IS_UTF8_STRINGS_INDEX)
+        }
+
+        return bits
+    }
+
+    fun toBinarySerializationCompatInfo(): BinarySerializationCompatInfo {
+        return BinarySerializationCompatInfo(toBinarySerializationCompatInfoBits())
     }
 
     override fun equals(other: Any?) = equalsPattern(other) { o ->
-        newMeaningFormat == o.newMeaningFormat
+        newMeaningFormat == o.newMeaningFormat && isUtf8Strings == o.isUtf8Strings
     }
 
     override fun hashCode(): Int {
-        return if (newMeaningFormat) 1 else 0
+        // toInt() is lossless because currently only 2 bits are used.
+        return toBinarySerializationCompatInfoBits().toInt()
     }
 
     override fun toString(): String {
-        return "BackupCompatInfo(newMeaningFormat=$newMeaningFormat)"
+        return "BackupCompatInfo(newMeaningFormat=$newMeaningFormat, isUtf8Used=$isUtf8Strings)"
     }
 
     companion object {
         private val EMPTY = BackupCompatInfo()
 
         const val NEW_MEANING_FORMAT_INDEX = 0
+        const val IS_UTF8_STRINGS_INDEX = 1
 
         fun empty() = EMPTY
     }

--- a/app/src/main/java/io/github/pelmenstar1/digiDict/backup/BackupManager.kt
+++ b/app/src/main/java/io/github/pelmenstar1/digiDict/backup/BackupManager.kt
@@ -28,7 +28,7 @@ object BackupManager {
         put(BackupFormat.JSON, JsonDataImporter())
     }
 
-    val latestCompatInfo = BackupCompatInfo(newMeaningFormat = true)
+    val latestCompatInfo = BackupCompatInfo(newMeaningFormat = true, isUtf8Strings = true)
 
     fun createBackupData(
         appDatabase: AppDatabase,

--- a/app/src/main/java/io/github/pelmenstar1/digiDict/backup/exporting/JsonDataExporter.kt
+++ b/app/src/main/java/io/github/pelmenstar1/digiDict/backup/exporting/JsonDataExporter.kt
@@ -23,12 +23,12 @@ class JsonDataExporter : DataExporter {
 
             when (version) {
                 0 -> {
-                    wrappedData = data
-                    serializer = BackupData.serializer() as KSerializer<Any>
-                }
-                1 -> {
                     wrappedData = JsonBackupData0(data.records, data.badges, data.badgeToMultipleRecordEntries)
                     serializer = JsonBackupData0.serializer() as KSerializer<Any>
+                }
+                1 -> {
+                    wrappedData = data
+                    serializer = BackupData.serializer() as KSerializer<Any>
                 }
                 else -> throw IllegalArgumentException("Invalid version ($version)")
             }

--- a/app/src/main/java/io/github/pelmenstar1/digiDict/data/Record.kt
+++ b/app/src/main/java/io/github/pelmenstar1/digiDict/data/Record.kt
@@ -4,6 +4,7 @@ import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.Index
 import androidx.room.PrimaryKey
+import io.github.pelmenstar1.digiDict.backup.BackupCompatInfo
 import io.github.pelmenstar1.digiDict.common.binarySerialization.BinarySerializerResolver
 import io.github.pelmenstar1.digiDict.common.equalsPattern
 import kotlinx.serialization.Serializable
@@ -60,17 +61,21 @@ open class Record(
         val SERIALIZER_RESOLVER = BinarySerializerResolver<Record> {
             register<Record>(
                 version = 1,
-                write = { value, _ ->
-                    emit(value.expression)
-                    emit(value.meaning)
-                    emit(value.additionalNotes)
+                write = { value, compatInfo ->
+                    val isUtf8 = compatInfo[BackupCompatInfo.IS_UTF8_STRINGS_INDEX]
+
+                    emitString(value.expression, isUtf8)
+                    emitString(value.meaning, isUtf8)
+                    emitString(value.additionalNotes, isUtf8)
                     emit(value.score)
                     emit(value.epochSeconds)
                 },
-                read = {
-                    val expression = consumeStringUtf16()
-                    val meaning = consumeStringUtf16()
-                    val additionalNotes = consumeStringUtf16()
+                read = { compatInfo ->
+                    val isUtf8 = compatInfo[BackupCompatInfo.IS_UTF8_STRINGS_INDEX]
+
+                    val expression = consumeString(isUtf8)
+                    val meaning = consumeString(isUtf8)
+                    val additionalNotes = consumeString(isUtf8)
                     val score = consumeInt()
                     val epochSeconds = consumeLong()
 

--- a/app/src/main/java/io/github/pelmenstar1/digiDict/data/RecordBadgeInfo.kt
+++ b/app/src/main/java/io/github/pelmenstar1/digiDict/data/RecordBadgeInfo.kt
@@ -5,6 +5,7 @@ import android.os.Parcelable
 import androidx.room.Entity
 import androidx.room.Index
 import androidx.room.PrimaryKey
+import io.github.pelmenstar1.digiDict.backup.BackupCompatInfo
 import io.github.pelmenstar1.digiDict.common.android.readStringOrThrow
 import io.github.pelmenstar1.digiDict.common.binarySerialization.BinarySerializerResolver
 import io.github.pelmenstar1.digiDict.common.equalsPattern
@@ -73,12 +74,12 @@ class RecordBadgeInfo : Parcelable, EntityWithPrimaryKeyId {
         val SERIALIZER_RESOLVER = BinarySerializerResolver<RecordBadgeInfo> {
             register<RecordBadgeInfo>(
                 version = 1,
-                write = { value, _ ->
-                    emit(value.name)
+                write = { value, compatInfo ->
+                    emitString(value.name, compatInfo[BackupCompatInfo.IS_UTF8_STRINGS_INDEX])
                     emit(value.outlineColor)
                 },
-                read = {
-                    val name = consumeStringUtf16()
+                read = { compatInfo ->
+                    val name = consumeString(compatInfo[BackupCompatInfo.IS_UTF8_STRINGS_INDEX])
                     val color = consumeInt()
 
                     RecordBadgeInfo(0, name, color)

--- a/common/src/main/java/io/github/pelmenstar1/digiDict/common/Text.Utf8.kt
+++ b/common/src/main/java/io/github/pelmenstar1/digiDict/common/Text.Utf8.kt
@@ -1,0 +1,119 @@
+package io.github.pelmenstar1.digiDict.common
+
+// Basically, this is Square Okio Utf8.kt with some minor changes.
+// https://github.com/square/okio/blob/master/okio/src/commonMain/kotlin/okio/Utf8.kt
+
+internal const val REPLACEMENT_BYTE: Byte = '?'.code.toByte()
+
+internal fun String.utf8Size(): Int {
+    val length = length
+    var result = 0
+
+    var i = 0
+    while (i < length) {
+        val c = this[i].code
+
+        if (c < 0x80) {
+            // A 7-bit character with 1 byte.
+            result++
+            i++
+        } else if (c < 0x800) {
+            // An 11-bit character with 2 bytes.
+            result += 2
+            i++
+        } else if (c < 0xd800 || c > 0xdfff) {
+            // A 16-bit character with 3 bytes.
+            result += 3
+            i++
+        } else {
+            val low = if (i + 1 < length) this[i + 1].code else 0
+
+            if (c > 0xdbff || low < 0xdc00 || low > 0xdfff) {
+                // A malformed surrogate, which yields '?'.
+                result++
+                i++
+            } else {
+                // A 21-bit character with 4 bytes.
+                result += 4
+                i += 2
+            }
+        }
+    }
+
+    return result
+}
+
+internal inline fun String.processUtf8Bytes(
+    on1Byte: (Byte) -> Unit,
+    on2Byte: (Byte, Byte) -> Unit,
+    on3Byte: (Byte, Byte, Byte) -> Unit,
+    on4Byte: (Byte, Byte, Byte, Byte) -> Unit
+) {
+    // Transcode a UTF-16 String to UTF-8 bytes.
+    var index = 0
+    val length = length
+
+    while (index < length) {
+        val c = this[index]
+
+        when {
+            c < '\u0080' -> {
+                // Emit a 7-bit character with 1 byte.
+                on1Byte(c.code.toByte()) // 0xxxxxxx
+                index++
+
+                // Assume there is going to be more ASCII
+                while (index < length && this[index] < '\u0080') {
+                    on1Byte(this[index++].code.toByte())
+                }
+            }
+
+            c < '\u0800' -> {
+                // Emit a 11-bit character with 2 bytes.
+                on2Byte(
+                    (c.code shr 6 or 0xc0).toByte(), // 110xxxxx
+                    (c.code and 0x3f or 0x80).toByte() // 10xxxxxx
+                )
+
+                index++
+            }
+
+            c !in '\ud800'..'\udfff' -> {
+                // Emit a 16-bit character with 3 bytes.
+                on3Byte(
+                    (c.code shr 12 or 0xe0).toByte(), // 1110xxxx
+                    (c.code shr 6 and 0x3f or 0x80).toByte(), // 10xxxxxx
+                    (c.code and 0x3f or 0x80).toByte() // 10xxxxxx
+                )
+
+                index++
+            }
+
+            else -> {
+                // c is a surrogate. Make sure it is a high surrogate & that its successor is a low
+                // surrogate. If not, the UTF-16 is invalid, in which case we emit a replacement
+                // byte.
+
+                if (c > '\udbff' || length <= index + 1 || this[index + 1] !in '\udc00'..'\udfff') {
+                    on1Byte(REPLACEMENT_BYTE)
+                    index++
+                } else {
+                    // UTF-16 high surrogate: 110110xxxxxxxxxx (10 bits)
+                    // UTF-16 low surrogate:  110111yyyyyyyyyy (10 bits)
+                    // Unicode code point:    00010000000000000000 + xxxxxxxxxxyyyyyyyyyy (21 bits)
+                    val codePoint = (((c.code shl 10) + this[index + 1].code) + (0x010000 - (0xd800 shl 10) - 0xdc00))
+
+                    // Emit a 21-bit character with 4 bytes.
+                    on4Byte(
+                        (codePoint shr 18 or 0xf0).toByte(), // 11110xxx
+                        (codePoint shr 12 and 0x3f or 0x80).toByte(), // 10xxxxxx
+                        (codePoint shr 6 and 0x3f or 0x80).toByte(), // 10xxyyyy
+                        (codePoint and 0x3f or 0x80).toByte() // 10yyyyyy
+                    )
+
+                    index += 2
+                }
+            }
+        }
+    }
+}

--- a/common/src/main/java/io/github/pelmenstar1/digiDict/common/binarySerialization/PrimitiveValueReader.kt
+++ b/common/src/main/java/io/github/pelmenstar1/digiDict/common/binarySerialization/PrimitiveValueReader.kt
@@ -178,6 +178,8 @@ class PrimitiveValueReader(private val inputStream: InputStream, bufferSize: Int
         return String(cb, 0, charLength)
     }
 
+    fun consumeString(isUtf8: Boolean): String = if (isUtf8) consumeStringUtf8() else consumeStringUtf16()
+
     fun consumeIntArray(dest: IntArray, start: Int, end: Int) {
         for (i in start until end) {
             dest[i] = consumeInt()

--- a/common/src/main/java/io/github/pelmenstar1/digiDict/common/binarySerialization/PrimitiveValueReader.kt
+++ b/common/src/main/java/io/github/pelmenstar1/digiDict/common/binarySerialization/PrimitiveValueReader.kt
@@ -13,12 +13,9 @@ import kotlin.math.min
  * Because of its stream nature, there's no going back and the cursor can't be moved forward or backward.
  *
  * The reader is already optimized for buffer reading, thus a reasonable buffer size should be specified in constructor.
- * There are several limitations imposed on buffer size:
- * - It should be greater than or equals to 8.
- * - It should be even.
  */
 class PrimitiveValueReader(private val inputStream: InputStream, bufferSize: Int) {
-    private val byteBufferArray = ByteArray(bufferSize)
+    private val byteBuffer = ByteArray(bufferSize)
 
     // Stores the amount of bytes that was consumed (read) in byteBuffer. The value should be even.
     private var consumedByteLength = 0
@@ -27,61 +24,25 @@ class PrimitiveValueReader(private val inputStream: InputStream, bufferSize: Int
     // If there was no call to inputStream.read and buffer is effectively zeroed, it's -1 (default value).
     private var actualBufferLength = -1
 
-    // A cached reference to the char array which is used in consumeStringUtf16() to write a char data to it and create a string using this array.
+    // A cached reference to the char array which is used in consumeStringUtf8/16() to write a char data to it and create a string using this array.
     // The size of the array is only extended when a string with bigger length than the array's one is requested.
-    // Outside the consumeStringUtf16() method, the array's content should be considered as garbage.
+    // Outside the consumeStringUtf8/16() method, the array's content should be considered as garbage.
     private var charBuffer: CharArray? = null
 
-    private var byteBuffer: ByteBuffer? = null
-    private var byteBufferAsCharHolder: CharBuffer? = null
-    private var byteBufferAsIntHolder: IntBuffer? = null
+    private var byteBufferForStrings: ByteArray? = null
 
-    init {
-        when {
-            bufferSize < 8 -> throw IllegalArgumentException("bufferSize should be greater than or equals to 8")
-            bufferSize % 2 != 0 -> throw IllegalArgumentException("bufferSize should be even")
-        }
-    }
+    fun consumeByte(): Byte {
+        invalidateBufferIfNecessary(minLength = 1)
 
-    private fun getByteBuffer(): ByteBuffer {
-        return getLazyValue(
-            byteBuffer,
-            {
-                ByteBuffer.wrap(byteBufferArray).apply {
-                    order(ByteOrder.LITTLE_ENDIAN)
-                }
-            },
-            { byteBuffer = it }
-        )
-    }
-
-    private fun getByteBufferAsChar(): CharBuffer {
-        return getLazyValue(
-            byteBufferAsCharHolder,
-            { getByteBuffer().asCharBuffer() },
-            { byteBufferAsCharHolder = it }
-        )
-    }
-
-    private fun getByteBufferAsInt(): IntBuffer {
-        return getLazyValue(
-            byteBufferAsIntHolder,
-            { getByteBuffer().asIntBuffer() },
-            { byteBufferAsIntHolder = it }
-        )
+        return byteBuffer[consumedByteLength++]
     }
 
     fun consumeShort(): Short {
-        // Short (2 bytes) consumption is special because as consumedByteLength should be even and buffer size is greater than or equals to 8,
-        // there can't be cross-buffer read. The logic can be simpler comparing to general consumePrimitive.
-        invalidateBufferIfNecessary(minLength = 2)
+        return consumeNumberPrimitiveInLong(byteCount = 2).toShort()
+    }
 
-        val consumedBytes = consumedByteLength
-
-        val result = byteBufferArray.readShort(consumedBytes)
-        consumedByteLength = consumedBytes + 2
-
-        return result
+    private fun consumeShortAsUnsignedInt(): Int {
+        return consumeShort().toInt() and 0xFFFF
     }
 
     fun consumeInt() = consumeNumberPrimitiveInLong(byteCount = 4).toInt()
@@ -91,7 +52,7 @@ class PrimitiveValueReader(private val inputStream: InputStream, bufferSize: Int
         // Locals should be assigned after buffer invalidation.
         invalidateBufferIfNecessary(minLength = byteCount)
 
-        val bb = byteBufferArray
+        val bb = byteBuffer
         val bufSize = bb.size
         val input = inputStream
         var actualBufLength = actualBufferLength
@@ -124,8 +85,72 @@ class PrimitiveValueReader(private val inputStream: InputStream, bufferSize: Int
         return result
     }
 
+    fun consumeStringUtf8(): String {
+        val utf8ByteLength = consumeShortAsUnsignedInt()
+
+        // It saves a couple of allocations.
+        if (utf8ByteLength == 0) {
+            return ""
+        }
+
+        val buf = byteBuffer
+        val bufSize = buf.size
+        var actualBufLength = actualBufferLength
+        var consumedBytes = consumedByteLength
+        val remBytesInBuf = actualBufLength - consumedBytes
+
+        val result: String
+
+        if (utf8ByteLength < remBytesInBuf) {
+            result = String(buf, consumedBytes, utf8ByteLength, Charsets.UTF_8)
+            consumedBytes += utf8ByteLength
+        } else {
+            var bufForStrings = byteBufferForStrings
+            if (bufForStrings == null || utf8ByteLength > bufForStrings.size) {
+                bufForStrings = ByteArray(utf8ByteLength)
+                byteBufferForStrings = bufForStrings
+            }
+
+            System.arraycopy(buf, consumedBytes, bufForStrings, 0, remBytesInBuf)
+            var remBytesToRead = utf8ByteLength - remBytesInBuf
+            var offset = remBytesInBuf
+
+            while (remBytesToRead >= bufSize) {
+                inputStream.readExact(bufForStrings, offset, length = bufSize)
+
+                offset += bufSize
+                remBytesToRead -= bufSize
+            }
+
+            if (remBytesToRead > 0) {
+                actualBufLength = inputStream.readAtLeast(
+                    buf,
+                    offset = 0,
+                    minLength = remBytesToRead,
+                    maxLength = bufSize
+                )
+
+                System.arraycopy(buf, 0, bufForStrings, offset, remBytesToRead)
+
+                consumedBytes = remBytesToRead
+            } else {
+                consumedBytes = 0
+
+                // Buffer must be invalidated on the next read.
+                actualBufLength = -1
+            }
+
+            result = String(bufForStrings, 0, utf8ByteLength, Charsets.UTF_8)
+        }
+
+        consumedByteLength = consumedBytes
+        actualBufferLength = actualBufLength
+
+        return result
+    }
+
     fun consumeStringUtf16(): String {
-        val charLength = consumeShort().toInt() and 0xFFFF
+        val charLength = consumeShortAsUnsignedInt()
 
         // It saves a couple of allocations.
         if (charLength == 0) {
@@ -138,32 +163,17 @@ class PrimitiveValueReader(private val inputStream: InputStream, bufferSize: Int
             charBuffer = cb
         }
 
-        consumeCharArray(cb, 0, charLength)
+        for (i in 0 until charLength) {
+            cb[i] = consumeShort().toInt().toChar()
+        }
+
         return String(cb, 0, charLength)
     }
 
-    fun consumeCharArray(dest: CharArray, start: Int, end: Int) {
-        // Consumption of char array is always "aligned" as consumedByteLength is always even.
-        consumePrimitiveArrayAligned(dest, start, end, elementSize = 2, getByteBufferAsChar(), CharBuffer::get)
-    }
-
     fun consumeIntArray(dest: IntArray, start: Int, end: Int) {
-        consumePrimitiveArray(
-            dest,
-            start,
-            end,
-            elementSize = 4,
-            this::consumeIntArrayAligned,
-            this::consumeIntArrayNonAligned
-        )
-    }
-
-    private fun consumeIntArrayAligned(dest: IntArray, start: Int, end: Int) {
-        consumePrimitiveArrayAligned(dest, start, end, elementSize = 4, getByteBufferAsInt(), IntBuffer::get)
-    }
-
-    private fun consumeIntArrayNonAligned(dest: IntArray, start: Int, end: Int) {
-        consumePrimitiveArrayNonAligned(dest, start, end, IntArray::set, this::consumeInt)
+        for (i in start until end) {
+            dest[i] = consumeInt()
+        }
     }
 
     fun consumeIntArray(length: Int): IntArray {
@@ -174,115 +184,6 @@ class PrimitiveValueReader(private val inputStream: InputStream, bufferSize: Int
         val length = consumeInt()
 
         return consumeIntArray(length)
-    }
-
-    private inline fun <TArray> consumePrimitiveArray(
-        dest: TArray,
-        start: Int,
-        end: Int,
-        elementSize: Int,
-        consumeAligned: (TArray, Int, Int) -> Unit,
-        consumeNonAligned: (TArray, Int, Int) -> Unit,
-    ) {
-        if (consumedByteLength % elementSize == 0) {
-            consumeAligned(dest, start, end)
-        } else {
-            consumeNonAligned(dest, start, end)
-        }
-    }
-
-    /**
-     * A builder for creating a function that consumes a primitive array
-     * when [consumedByteLength] is not a multiple of count of bytes required to store [TValue].
-     *
-     * The performance of the implementation can be improved by using [IntBuffer]
-     * and another things used in [consumePrimitiveArrayAligned] but the effort is probably not worth it.
-     */
-    private inline fun <TValue, TArray> consumePrimitiveArrayNonAligned(
-        dest: TArray,
-        start: Int,
-        end: Int,
-        setValue: TArray.(Int, TValue) -> Unit,
-        consumePrimitive: () -> TValue
-    ) {
-        for (i in start until end) {
-            dest.setValue(i, consumePrimitive())
-        }
-    }
-
-    /**
-     * A builder for creating a function that consumes a primitive array when [consumedByteLength] is a multiple of [elementSize].
-     * If [consumedByteLength] is not a multiple of [elementSize], the result will be wrong.
-     */
-    private inline fun <TArray : Any, TBuffer : Buffer> consumePrimitiveArrayAligned(
-        dest: TArray,
-        start: Int,
-        end: Int,
-        elementSize: Int,
-        elementBuffer: TBuffer,
-        getArray: TBuffer.(TArray, start: Int, length: Int) -> Unit
-    ) {
-        val length = end - start
-        val byteLength = length * elementSize
-
-        // Locals should be assigned after buffer invalidation.
-        invalidateBufferIfNecessary(minLength = byteLength)
-
-        val bb = byteBufferArray
-        val bufSize = bb.size
-        val bufSizeAsElement = bufSize / elementSize
-        val alignedBufSize = bufSizeAsElement * elementSize
-
-        val input = inputStream
-        var actualBufLength = actualBufferLength
-        var consumedBytes = consumedByteLength
-        var elemPos = start
-
-        val remCachedBytes = actualBufLength - consumedBytes
-
-        val prefixByteLength = min(byteLength, remCachedBytes)
-        val prefixElementLength = prefixByteLength / elementSize
-
-        elementBuffer.position(consumedBytes / elementSize)
-        elementBuffer.getArray(dest, start, prefixElementLength)
-        elemPos += prefixElementLength
-        consumedBytes += prefixByteLength
-
-        // If we can't read a full content of a string from existing buffer, we should read from InputStream to fulfill char buffer.
-        if (elemPos != end) {
-            var remElements: Int
-            while (true) {
-                remElements = end - elemPos
-
-                // Bail out if we can't read a full byte buffer.
-                if (remElements < bufSizeAsElement) {
-                    break
-                }
-
-                input.readExact(bb, 0, alignedBufSize)
-
-                elementBuffer.position(0)
-                elementBuffer.getArray(dest, elemPos, bufSizeAsElement)
-
-                elemPos += bufSizeAsElement
-            }
-
-            // Read from InputStream if some chars are still remaining.
-            if (remElements > 0) {
-                val remElementsAsByte = remElements * elementSize
-                actualBufLength = input.readAtLeast(bb, 0, minLength = remElementsAsByte, maxLength = bufSize)
-
-                elementBuffer.position(0)
-                elementBuffer.getArray(dest, elemPos, remElements)
-
-                consumedBytes = remElementsAsByte
-            } else {
-                consumedBytes = 0
-            }
-        }
-
-        consumedByteLength = consumedBytes
-        actualBufferLength = actualBufLength
     }
 
     @Suppress("UNCHECKED_CAST")
@@ -302,7 +203,7 @@ class PrimitiveValueReader(private val inputStream: InputStream, bufferSize: Int
     }
 
     private fun invalidateBufferIfNecessary(minLength: Int) {
-        val bb = byteBufferArray
+        val bb = byteBuffer
         val bufSize = bb.size
 
         // The buffer should be invalidated when either no data was written to it or all the bytes in the buffer is consumed.

--- a/common/src/main/java/io/github/pelmenstar1/digiDict/common/binarySerialization/PrimitiveValueWriter.kt
+++ b/common/src/main/java/io/github/pelmenstar1/digiDict/common/binarySerialization/PrimitiveValueWriter.kt
@@ -1,9 +1,10 @@
 package io.github.pelmenstar1.digiDict.common.binarySerialization
 
-import io.github.pelmenstar1.digiDict.common.*
+import io.github.pelmenstar1.digiDict.common.ProgressReporter
+import io.github.pelmenstar1.digiDict.common.processUtf8Bytes
+import io.github.pelmenstar1.digiDict.common.trackLoopProgressWith
+import io.github.pelmenstar1.digiDict.common.utf8Size
 import java.io.OutputStream
-import java.nio.*
-import kotlin.math.min
 
 /**
  * Provides means for writing primitive types (like [Int], [Long], [String]) to [OutputStream].
@@ -13,84 +14,94 @@ import kotlin.math.min
  * Because of its stream nature, there's no going back and the cursor can't be moved forward or backward.
  *
  * The writer is already buffered, thus a reasonable buffer size should be specified in constructor.
- * There are several limitations imposed on buffer size:
- * - It should be greater than or equals to 8.
- * - It should be even.
  */
 class PrimitiveValueWriter(private val output: OutputStream, bufferSize: Int) {
     private val byteBufferArray = ByteArray(bufferSize)
-
-    private var byteBuffer: ByteBuffer? = null
-
-    // A CharBuffer which can effectively write chars to byteBufferArray
-    private var byteBufferAsCharHolder: CharBuffer? = null
-
-    // A IntBuffer which can effectively write ints to byteBufferArray
-    private var byteBufferAsIntHolder: IntBuffer? = null
-    private var byteBufferAsIntOffset = 0
-
-    // A cached reference to the char array which is used in emit(String) to write a char data to it and write the array to the stream.
-    // There's a temporary step with the char array because CharBuffer (when mapped from ByteBuffer)
-    // provides optimized way for writing CharArray but not String.
-    //
-    // The size of the array is only extended when a string with bigger length than the array's one is requested.
-    // Outside the emit(String) method, the array's content should be considered as garbage.
-    private var charBuffer: CharArray? = null
 
     // Stores a current position in byteBufferArray from which writing the data should start.
     // It can't equal to byteBufferArray.size and should be even.
     private var bufferPos = 0
 
-    init {
-        when {
-            bufferSize < 8 -> throw IllegalArgumentException("bufferSize should be greater than or equals to 8")
-            bufferSize % 2 != 0 -> throw IllegalArgumentException("bufferSize should be even")
+    fun emit(b: Byte) {
+        val buf = byteBufferArray
+        var bp = bufferPos
+        val remaining = buf.size - bp
+
+        if (remaining == 0) {
+            output.write(buf, 0, buf.size)
+            bp = 0
         }
+
+        buf[bp++] = b
+        setBufferPosAndSyncIfNecessary(bp)
     }
 
-    private fun getByteBuffer(): ByteBuffer {
-        return getLazyValue(
-            byteBuffer,
-            {
-                ByteBuffer.wrap(byteBufferArray).apply {
-                    order(ByteOrder.LITTLE_ENDIAN)
-                }
+    private fun emit2Bytes(b1: Byte, b2: Byte) {
+        emitNBytes(
+            length = 2,
+            common = {
+                emit(b1)
+                emit(b2)
             },
-            { byteBuffer = it }
+            fast = { buf, bp ->
+                buf[bp] = b1
+                buf[bp + 1] = b2
+            }
         )
     }
 
-    // offset is not used and its only purpose is to match a lambda signature in emitArray()
-    private fun getByteBufferAsChar(@Suppress("UNUSED_PARAMETER") offset: Int = 0): CharBuffer {
-        return getLazyValue(
-            byteBufferAsCharHolder,
-            { getByteBuffer().asCharBuffer() },
-            { byteBufferAsCharHolder = it }
+    private fun emit3Bytes(b1: Byte, b2: Byte, b3: Byte) {
+        emitNBytes(
+            length = 3,
+            common = {
+                emit(b1)
+                emit(b2)
+                emit(b3)
+            },
+            fast = { buf, bp ->
+                buf[bp] = b1
+                buf[bp + 1] = b2
+                buf[bp + 2] = b3
+            }
         )
     }
 
-    private fun getByteBufferAsInt(offset: Int): IntBuffer {
-        var bbAsInt = byteBufferAsIntHolder
+    private fun emit4Bytes(b1: Byte, b2: Byte, b3: Byte, b4: Byte) {
+        emitNBytes(
+            length = 4,
+            common = {
+                emit(b1)
+                emit(b2)
+                emit(b3)
+                emit(b4)
+            },
+            fast = { buf, bp ->
+                buf[bp] = b1
+                buf[bp + 1] = b2
+                buf[bp + 2] = b3
+                buf[bp + 3] = b4
+            }
+        )
+    }
 
-        if (bbAsInt == null || byteBufferAsIntOffset != offset) {
-            val bb = getByteBuffer()
-            bb.position(offset)
-            bbAsInt = bb.asIntBuffer()
+    private inline fun emitNBytes(length: Int, common: () -> Unit, fast: (buf: ByteArray, bp: Int) -> Unit) {
+        val buf = byteBufferArray
+        val bp = bufferPos
+        val remaining = buf.size - bp
+
+        if (remaining < length) {
+            common()
+        } else {
+            fast(buf, bp)
+
+            setBufferPosAndSyncIfNecessary(bp + length)
         }
-
-        byteBufferAsIntHolder = bbAsInt
-        byteBufferAsIntOffset = offset
-
-        return bbAsInt!!
     }
+
+    fun emit(c: Char) = emit(c.code.toShort())
 
     fun emit(value: Short) {
-        // Short (2 bytes) emission is special because as bufferPos should be even and buffer size is greater than or equals to 8,
-        // there can't be cross-buffer writing. The logic can be simpler comparing to general emitPrimitive.
-        val bp = bufferPos
-
-        value.writeTo(byteBufferArray, bp)
-        setBufferPosAndSyncIfNecessary(bp + 2)
+        emitNumberPrimitive(value.toLong(), byteCount = 2)
     }
 
     fun emit(value: Int) {
@@ -101,10 +112,7 @@ class PrimitiveValueWriter(private val output: OutputStream, bufferSize: Int) {
         emitNumberPrimitive(value, byteCount = 8)
     }
 
-    private fun emitNumberPrimitive(
-        value: Long,
-        byteCount: Int
-    ) {
+    private fun emitNumberPrimitive(value: Long, byteCount: Int) {
         val buf = byteBufferArray
         var bp = bufferPos
         val remaining = buf.size - bp
@@ -128,31 +136,33 @@ class PrimitiveValueWriter(private val output: OutputStream, bufferSize: Int) {
         setBufferPosAndSyncIfNecessary(bp)
     }
 
-    fun emit(value: String) {
-        var cb = charBuffer
+    fun emitUtf8(value: String) {
+        val utf8Size = value.utf8Size()
+
+        checkStringLength(utf8Size)
+        emit(utf8Size.toShort())
+
+        value.processUtf8Bytes(
+            on1Byte = ::emit,
+            on2Byte = ::emit2Bytes,
+            on3Byte = ::emit3Bytes,
+            on4Byte = ::emit4Bytes,
+        )
+    }
+
+    fun emitUtf16(value: String) {
         val valueLength = value.length
 
         checkStringLength(valueLength)
         emit(valueLength.toShort())
 
-        // It saves a few allocations if the string is empty.
-        if (valueLength > 0) {
-            if (cb == null || valueLength > cb.size) {
-                cb = CharArray(valueLength)
-                charBuffer = cb
-            }
-
-            value.toCharArray(cb)
-            emit(cb, 0, valueLength)
+        for (i in 0 until valueLength) {
+            emit(value[i])
         }
     }
 
-    fun emit(chars: CharArray, start: Int, end: Int) {
-        emitPrimitiveArray(chars, start, end, elementSize = 2, this::getByteBufferAsChar, CharBuffer::put)
-    }
-
     fun emit(ints: IntArray, start: Int, end: Int) {
-        emitPrimitiveArray(ints, start, end, elementSize = 4, this::getByteBufferAsInt, IntBuffer::put)
+        emitPrimitiveArray(ints, start, end, IntArray::get, ::emit)
     }
 
     fun emitArrayAndLength(ints: IntArray, start: Int = 0, end: Int = ints.size) {
@@ -162,69 +172,15 @@ class PrimitiveValueWriter(private val output: OutputStream, bufferSize: Int) {
         emit(ints, start, end)
     }
 
-    private inline fun <TArray : Any, TBuffer : Buffer> emitPrimitiveArray(
+    private inline fun <TArray, TElement> emitPrimitiveArray(
         array: TArray,
-        start: Int,
-        end: Int,
-        elementSize: Int,
-        getElementBuffer: (offset: Int) -> TBuffer,
-        putArray: TBuffer.(TArray, start: Int, length: Int) -> Unit
+        start: Int, end: Int,
+        getElement: TArray.(index: Int) -> TElement,
+        emitElement: (TElement) -> Unit
     ) {
-        val out = output
-        val bb = byteBufferArray
-        var bp = bufferPos
-        val bufSize = bb.size
-
-        val elemPos = bp / elementSize
-        val elemOffset = bp % elementSize
-        val offsetElemBuffer = getElementBuffer(elemOffset)
-
-        val elementLength = end - start
-
-        offsetElemBuffer.position(elemPos)
-        val remElementsInByteBuffer = (bufSize - bp) / elementSize
-
-        val prefixElemLength = min(remElementsInByteBuffer, elementLength)
-        offsetElemBuffer.putArray(array, start, prefixElemLength)
-        bp += prefixElemLength * elementSize
-
-        if (prefixElemLength != elementLength) {
-            // We've written what we can to the buffer which means we need to write it down the stream and start to re-fill the buffer.
-            out.write(bb, 0, bp)
-
-            var elementPos = start + prefixElemLength
-            val elemBuffer = getElementBuffer(0)
-            val bufSizeAsElement = bufSize / elementSize
-            val alignedBufSize = bufSizeAsElement * elementSize
-
-            // Stores amount of elements that need to be written.
-            var remElements: Int
-
-            while (true) {
-                remElements = end - elementPos
-
-                // Exit the loop if we can't do full buffer write.
-                if (remElements < bufSizeAsElement) {
-                    break
-                }
-
-                elemBuffer.position(0)
-                elemBuffer.putArray(array, elementPos, bufSizeAsElement)
-
-                elementPos += bufSizeAsElement
-                out.write(bb, 0, alignedBufSize)
-            }
-
-            // Write suffix if it exists.
-            if (remElements > 0) {
-                elemBuffer.position(0)
-                elemBuffer.putArray(array, elementPos, remElements)
-            }
-
-            bp = remElements * elementSize
+        for (i in start until end) {
+            emitElement(array.getElement(i))
         }
-
-        setBufferPosAndSyncIfNecessary(bp)
     }
 
     fun <T : Any> emit(
@@ -245,6 +201,7 @@ class PrimitiveValueWriter(private val output: OutputStream, bufferSize: Int) {
         val bp = bufferPos
         if (bp > 0) {
             output.write(byteBufferArray, 0, bp)
+            bufferPos = 0
         }
     }
 

--- a/common/src/main/java/io/github/pelmenstar1/digiDict/common/binarySerialization/PrimitiveValueWriter.kt
+++ b/common/src/main/java/io/github/pelmenstar1/digiDict/common/binarySerialization/PrimitiveValueWriter.kt
@@ -161,6 +161,14 @@ class PrimitiveValueWriter(private val output: OutputStream, bufferSize: Int) {
         }
     }
 
+    fun emitString(value: String, isUtf8: Boolean) {
+        if (isUtf8) {
+            emitUtf8(value)
+        } else {
+            emitUtf16(value)
+        }
+    }
+
     fun emit(ints: IntArray, start: Int, end: Int) {
         emitPrimitiveArray(ints, start, end, IntArray::get, ::emit)
     }

--- a/common/src/test/java/io/github/pelmenstar1/digiDict/common/PrimitiveValueWriterReaderTests.kt
+++ b/common/src/test/java/io/github/pelmenstar1/digiDict/common/PrimitiveValueWriterReaderTests.kt
@@ -13,14 +13,14 @@ class PrimitiveValueWriterReaderTests {
     private class ShortOperation(value: Short) : Operation<Short>(value)
     private class IntOperation(value: Int) : Operation<Int>(value)
     private class LongOperation(value: Long) : Operation<Long>(value)
-    private class StringOperation(value: String) : Operation<String>(value)
+    private class StringOperation(value: String, val isUtf8: Boolean) : Operation<String>(value)
     private class IntArrayOperation(value: IntArray) : Operation<IntArray>(value)
 
     private class OperationChainBuilder(private val ops: MutableList<Operation<out Any>>) {
         fun short(value: Short) = add(ShortOperation(value))
         fun int(value: Int) = add(IntOperation(value))
         fun long(value: Long) = add(LongOperation(value))
-        fun string(value: String) = add(StringOperation(value))
+        fun string(value: String, isUtf8: Boolean) = add(StringOperation(value, isUtf8))
         fun intArray(value: IntArray) = add(IntArrayOperation(value))
 
         private fun add(op: Operation<out Any>) {
@@ -51,7 +51,7 @@ class PrimitiveValueWriterReaderTests {
                         is ShortOperation -> emit(op.value)
                         is IntOperation -> emit(op.value)
                         is LongOperation -> emit(op.value)
-                        is StringOperation -> emit(op.value)
+                        is StringOperation -> if (op.isUtf8) emitUtf8(op.value) else emitUtf16(op.value)
                         is IntArrayOperation -> emitArrayAndLength(op.value)
                     }
                 }
@@ -66,7 +66,7 @@ class PrimitiveValueWriterReaderTests {
                         is ShortOperation -> consumeShort()
                         is IntOperation -> consumeInt()
                         is LongOperation -> consumeLong()
-                        is StringOperation -> consumeStringUtf16()
+                        is StringOperation -> if (op.isUtf8) consumeStringUtf8() else consumeStringUtf16()
                         is IntArrayOperation -> consumeIntArrayAndLength()
                     }
                 }
@@ -91,13 +91,16 @@ class PrimitiveValueWriterReaderTests {
         int(-100)
         int(383)
         long(222L)
-        string("123")
+        string("123", isUtf8 = false)
+        string("abcdef", isUtf8 = true)
+        string("блаблабла", isUtf8 = true)  // Non-ASCII text
         int(0)
-        string("55555")
-        string("")
-        string("1")
-        string(bigString1)
-        string(bigString2)
+        string("55555", isUtf8 = true)
+        string("", isUtf8 = true)
+        string("1", isUtf8 = false)
+        string(bigString1, isUtf8 = true)
+        string(bigString2, isUtf8 = false)
+        string(bigString2, isUtf8 = true)
         intArray(intArrayOf(0, 1, 2, 3))
         intArray(intArrayOf(Int.MAX_VALUE, 245, 444, 8))
         intArray(IntArray(1024) { it })
@@ -109,16 +112,16 @@ class PrimitiveValueWriterReaderTests {
         int(-100)
         int(383)
         long(222L)
-        string("123")
-        string("44445")
+        string("123", isUtf8 = true)
+        string("44445", isUtf8 = true)
         int(0)
-        string("55555")
-        string("")
-        string("1")
-        string(bigString1)
-        string(bigString2)
+        string("55555", isUtf8 = true)
+        string("", isUtf8 = true)
+        string("1", isUtf8 = true)
+        string(bigString1, isUtf8 = true)
+        string(bigString2, isUtf8 = true)
         int(344)
-        string("123")
+        string("123", isUtf8 = true)
         long(1L)
         intArray(intArrayOf(Int.MAX_VALUE, 12, 3))
         long(0L)
@@ -135,7 +138,16 @@ class PrimitiveValueWriterReaderTests {
     fun readWriteNearBufferLimit() {
         readWriteTestHelper(bufferSize = 32) {
             // Make string to fulfill the buffer: 2 bytes for length, 2 bytes for each char => 2 + 15 * 2 = 32
-            string(" ".repeat(15))
+            string(" ".repeat(15), isUtf8 = false)
+
+            // Then write other data
+            int(123)
+        }
+
+        readWriteTestHelper(bufferSize = 32) {
+            // Make string to fulfill the buffer: 2 bytes for length, 2 bytes for each char => 2 + 15 * 2 = 32
+            // Also, non-ASCII text.
+            string("м".repeat(15), isUtf8 = true)
 
             // Then write other data
             int(123)
@@ -148,11 +160,27 @@ class PrimitiveValueWriterReaderTests {
             long(0L)
 
             // We've written 4 longs (8 * 4 = 32), then write a string.
-            string("123")
+            string("123", isUtf8 = false)
         }
 
         readWriteTestHelper(bufferSize = 32) {
-            string(" ".repeat(15))
+            long(8L)
+            long(Long.MAX_VALUE)
+            long(Long.MIN_VALUE)
+            long(0L)
+
+            // We've written 4 longs (8 * 4 = 32), then write a string.
+            string("123", isUtf8 = true)
+        }
+
+        readWriteTestHelper(bufferSize = 32) {
+            string(" ".repeat(15), isUtf8 = false)
+
+            intArray(intArrayOf(1, 2, 3, 4))
+        }
+
+        readWriteTestHelper(bufferSize = 32) {
+            string(" ".repeat(31), isUtf8 = true)
 
             intArray(intArrayOf(1, 2, 3, 4))
         }
@@ -162,7 +190,7 @@ class PrimitiveValueWriterReaderTests {
     fun readWriteCrossBuffer_int() {
         readWriteTestHelper(bufferSize = 32) {
             // Make string to almost reach the end of the buffer: 2 + 14 * 2 = 30
-            string(" ".repeat(14))
+            string(" ".repeat(14), isUtf8 = false)
 
             // Make cross-buffer write (low bits in current buffer, high bits in the same buffer but at another position)
             int(12)
@@ -172,7 +200,7 @@ class PrimitiveValueWriterReaderTests {
     @Test
     fun readWriteCrossBuffer_long() {
         readWriteTestHelper(bufferSize = 32) {
-            string(" ".repeat(14))
+            string(" ".repeat(14), isUtf8 = false)
 
             long(Long.MAX_VALUE)
         }
@@ -181,8 +209,13 @@ class PrimitiveValueWriterReaderTests {
     @Test
     fun readWriteCrossBuffer_string() {
         readWriteTestHelper(bufferSize = 32) {
-            string(" ".repeat(14))
-            string("1111")
+            string(" ".repeat(14), isUtf8 = false)
+            string("1111", isUtf8 = false)
+        }
+
+        readWriteTestHelper(bufferSize = 32) {
+            string(" ".repeat(30), isUtf8 = true)
+            string("1111", isUtf8 = true)
         }
     }
 
@@ -202,31 +235,60 @@ class PrimitiveValueWriterReaderTests {
     }
 
     @Test
-    fun readWriteString_1() {
+    fun readWriteString_1_utf16() {
         readWriteTestHelper(bufferSize = 128) {
-            string("123")
-            string("")
-            string("55555")
+            string("123", isUtf8 = false)
+            string("", isUtf8 = false)
+            string("55555", isUtf8 = false)
         }
     }
 
     @Test
-    fun readWriteString_2() {
+    fun readWriteString_smallStrings_utf8() {
         readWriteTestHelper(bufferSize = 128) {
-            string(bigString1)
-            string(bigString2)
+            string("123", isUtf8 = true)
+            string("", isUtf8 = true)
+            string("55555", isUtf8 = true)
         }
     }
 
     @Test
-    fun readWriteString_mixed() {
+    fun readWriteString_bigStrings_utf8() {
+        readWriteTestHelper(bufferSize = 128) {
+            string(bigString1, isUtf8 = true)
+            string(bigString2, isUtf8 = true)
+        }
+    }
+
+    @Test
+    fun readWriteString_bigStrings_utf16() {
+        readWriteTestHelper(bufferSize = 128) {
+            string(bigString1, isUtf8 = false)
+            string(bigString2, isUtf8 = false)
+        }
+    }
+
+    @Test
+    fun readWriteString_mixed_utf8() {
         readWriteTestHelper {
-            string(bigString2)
-            string("")
-            string("1")
-            string("111111")
-            string(bigString1)
-            string("33")
+            string(bigString2, isUtf8 = true)
+            string("", isUtf8 = true)
+            string("1", isUtf8 = true)
+            string("111111", isUtf8 = true)
+            string(bigString1, isUtf8 = true)
+            string("33", isUtf8 = true)
+        }
+    }
+
+    @Test
+    fun readWriteString_mixed_utf16() {
+        readWriteTestHelper {
+            string(bigString2, isUtf8 = false)
+            string("", isUtf8 = false)
+            string("1", isUtf8 = true)
+            string("111111", isUtf8 = false)
+            string(bigString1, isUtf8 = false)
+            string("33", isUtf8 = false)
         }
     }
 }

--- a/common/src/test/java/io/github/pelmenstar1/digiDict/common/PrimitiveValueWriterReaderTests.kt
+++ b/common/src/test/java/io/github/pelmenstar1/digiDict/common/PrimitiveValueWriterReaderTests.kt
@@ -51,7 +51,7 @@ class PrimitiveValueWriterReaderTests {
                         is ShortOperation -> emit(op.value)
                         is IntOperation -> emit(op.value)
                         is LongOperation -> emit(op.value)
-                        is StringOperation -> if (op.isUtf8) emitUtf8(op.value) else emitUtf16(op.value)
+                        is StringOperation -> emitString(op.value, op.isUtf8)
                         is IntArrayOperation -> emitArrayAndLength(op.value)
                     }
                 }
@@ -66,7 +66,7 @@ class PrimitiveValueWriterReaderTests {
                         is ShortOperation -> consumeShort()
                         is IntOperation -> consumeInt()
                         is LongOperation -> consumeLong()
-                        is StringOperation -> if (op.isUtf8) consumeStringUtf8() else consumeStringUtf16()
+                        is StringOperation -> consumeString(op.isUtf8)
                         is IntArrayOperation -> consumeIntArrayAndLength()
                     }
                 }


### PR DESCRIPTION
The backup size will be less, but importing and exporting will be a bit less effective as the Java strings are UTF-16.